### PR TITLE
Replace stub (^C^V) intro for "More advanced workflows"

### DIFF
--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -1,9 +1,9 @@
 # More advanced workflows
 
-One of the best parts about using a version control system is the ability to
-share that code with other people. So far, we've been using jj entirely on our
-own machine, but it's time to explore how we can interface with tools that let
-us collaborate.
+The workflows we've seen in `jj` are different from `git` in the best ways. As we
+get a bit more advanced, there are some very impressive possibilities yet to
+see. This section will also address an interesting aspect of interoperability
+between `jj` and `git`: colocated repositories.
 
 Here's what we're going to learn:
 


### PR DESCRIPTION
This section had an intro paragraph copied and pasted from the previous section (Sharing your code with others)--which is how I create new sections, too, to be fair--so I wrote a simple summary. The primary author will probably want to replace it in his own voice, but this is a more servicible stub in the meantime.